### PR TITLE
Fix versions

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -59,10 +59,10 @@
         -->
         <ul class="nav navbar-nav navbar-primary">
           <li ng-class="{active: isActive('/models')}">
-            <a href="#!/models">Models</a>
+            <a href="#/models">Models</a>
           </li>
           <li ng-class="{active: isActive('/queries')}">
-            <a href="#!/queries">Queries</a>
+            <a href="#/queries">Queries</a>
           </li>
         </ul>
       </div>

--- a/app/js/controllers/queriesModal.js
+++ b/app/js/controllers/queriesModal.js
@@ -39,7 +39,7 @@ angular.module("ophicleideWeb")
         }).then(function(result) {
           $log.info(result);
           $uibModalInstance.close();
-          $window.location.href = "/#!/queries";
+          $window.location.href = "/#/queries";
           $rootScope.refresh();
         }, function(error) {
           $uibModalInstance.close();

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   },
   "homepage": "https://github.com/ophicleide/ophicleide-web#readme",
   "dependencies": {
-    "angular": "^1.5.8",
-    "angular-animate": "^1.5.8",
-    "angular-patternfly": "^3.10.0",
-    "angular-route": "^1.5.8",
-    "angular-sanitize": "^1.5.8",
-    "angular-ui-bootstrap": "^2.1.3",
-    "body-parser": "^1.15.2",
-    "bootstrap": "^3.3.7",
-    "datatables": "^1.10.12",
-    "express": "^4.14.0",
-    "jquery": "^3.1.0",
-    "morgan": "^1.7.0",
-    "patternfly": "^3.9.0",
-    "request": "^2.75.0"
+    "angular": "1.5.8",
+    "angular-animate": "1.5.8",
+    "angular-patternfly": "3.10.0",
+    "angular-route": "1.5.8",
+    "angular-sanitize": "1.5.8",
+    "angular-ui-bootstrap": "2.1.3",
+    "body-parser": "1.15.2",
+    "bootstrap": "3.3.7",
+    "datatables": "1.10.12",
+    "express": "4.14.0",
+    "jquery": "3.1.0",
+    "morgan": "1.7.0",
+    "patternfly": "3.9.0",
+    "request": "2.75.0"
   }
 }


### PR DESCRIPTION
this change makes the dependency version locked, there have been several changes in the angular code base that cause issues. these should ultimately be fixed, but as this is a tutorial application we need it to work out of the box, locking the versions will help with this.

closes issue #3 